### PR TITLE
Fix type spec.

### DIFF
--- a/src/lejson.erl
+++ b/src/lejson.erl
@@ -73,7 +73,7 @@ encode_datetime({{H,M,D},{Hh,Mm,Ss}}) ->
 
 %% Decode ---------------------------------------------------------------------
 
--spec decode(iolist()) -> list() | map() | {error, not_json}.
+-spec decode(string() | binary()) -> list() | map() | {error, not_json}.
 decode(Str) when is_binary(Str) ->
     decode(binary_to_list(Str));
 decode(Str) ->


### PR DESCRIPTION
`lejson:decode([<<"{\"a\"">>, ":", $1, "}"])` will return `{error, not_json}` due to the way `is_json/1` is implemented. This PR fixes the spec to restrict the input to valid data structures only.
