### PR TITLE
Integers as keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ to keep with the standard (rfc4627). Encoding is also compatible with rfc8259.
                      | number() | binary() | json_object() | json_array().
 -type json_object() :: #{json_key() => json_value()}.
 -type json_array()  :: [json_value()].
--type json_opts()   :: #{'keys' => 'atom' | 'existing_atom' | 'list'}.
+-type json_opts()   :: #{'keys' => 'atom' | 'existing_atom' | 'list' |
+                         'integet_and_atom'}.
 
 -spec lejson:decode(iodata()) -> json_object() | json_array() | {error, not_json}.
 -spec lejson:decode(iodata(), json_opts()) ->

--- a/src/lejson.erl
+++ b/src/lejson.erl
@@ -23,7 +23,8 @@
                      | number() | binary() | json_object() | json_array().
 -type json_object() :: #{json_key() => json_value()}.
 -type json_array()  :: [json_value()].
--type json_opts()   :: #{'keys' => 'atom' | 'existing_atom' | 'list'}.
+-type json_opts()   :: #{'keys' => 'atom' | 'existing_atom' | 'list' |
+                         'integer_and_atom' }.
 
 %% Encode ---------------------------------------------------------------------
 

--- a/src/lejson.erl
+++ b/src/lejson.erl
@@ -52,6 +52,7 @@ encode_value(#{} = Map) -> encode_map(Map);
 encode_value(Array) when is_list(Array) -> encode_array(Array).
 
 encode_key(Key) when is_atom(Key) -> atom_to_binary(Key, utf8);
+encode_key(Key) when is_integer(Key) -> integer_to_binary(Key);
 encode_key(Key) -> Key.
 
 encode_string(Bin) when is_binary(Bin) ->

--- a/src/lejson.erl
+++ b/src/lejson.erl
@@ -257,4 +257,9 @@ is_json(_) -> false.
 convert_key(Key, #{keys:=atom}) -> binary_to_atom(Key, utf8);
 convert_key(Key, #{keys:=existing_atom}) -> binary_to_existing_atom(Key, utf8);
 convert_key(Key, #{keys:=list}) -> binary_to_list(Key);
+convert_key(Key, #{keys:=integer_and_atom}) ->
+    try binary_to_integer(Key)
+    catch
+        _:_ -> binary_to_atom(Key, utf8)
+    end;
 convert_key(Key, #{}) -> Key.

--- a/test/lejson_test.erl
+++ b/test/lejson_test.erl
@@ -8,14 +8,14 @@ config_test_() ->
      fun cleanup_config/1,
      {inorder, [ {timeout, 120,
                   {"encode", fun() -> test_encode({e,n,c}) end}},
-                [ {timeout, 120,
-                   {atom_to_list(Name),
-                    fun() -> test_opts(Data) end}} ||
-                    {Name,_,_,_} = Data <- maps_with_opts()]
-                 ++ [ {timeout, 120,
-                       {atom_to_list(Name),
-                        fun() -> test_decode(Data) end}} ||
-                        {Name,_,_} = Data <- json_strings_should_pass()]]}}.
+                 [ {timeout, 120,
+                    {atom_to_list(Name),
+                     fun() -> test_opts(Data) end}} ||
+                     {Name,_,_,_} = Data <- maps_with_opts()],
+                 [ {timeout, 120,
+                    {atom_to_list(Name),
+                     fun() -> test_decode(Data) end}} ||
+                     {Name,_,_} = Data <- json_strings_should_pass()]]}}.
 
 setup_config() -> ok.
 cleanup_config(_) -> ok.


### PR DESCRIPTION
We discovered that by accident lejson worked on using integers as keys, but only if the integer what 0-255. This fixes so all integers can be used as keys and with a new option they can be decoded to the same map as before encoding.

New option _integer_and_atom_

```
  1) lejson_test:config_test_/0: integer_as_key
     Failure/Error: {error,badarg,
                        [{erlang,iolist_to_binary,
                             [["{",["\"",256,"\"",":",[<<"1">>]],"}"]],
                             []},
                         {lejson,encode,1,
                             [{file,
                                  "/home/cjk/git/campanja/lejson/src/lejson.erl"},
                              {line,32}]},
                         {lejson_test,test_opts,1,
                             [{file,
                                  "/home/cjk/git/campanja/lejson/test/lejson_test.erl"},
                              {line,123}]},
                         {eunit_test,run_testfun,1,
                             [{file,"eunit_test.erl"},{line,71}]},
                         {eunit_proc,run_test,1,
                             [{file,"eunit_proc.erl"},{line,510}]},
                         {eunit_proc,with_timeout,3,
                             [{file,"eunit_proc.erl"},{line,335}]},
                         {eunit_proc,handle_test,2,
                             [{file,"eunit_proc.erl"},{line,493}]},
                         {eunit_proc,tests_inorder,3,
                             [{file,"eunit_proc.erl"},{line,435}]}]}
```